### PR TITLE
add nchar as arguement to writeZarrArray

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 1.9.1
+Version: 1.9.2
 Authors@R: c(person("Mike", "Smith", 
                 role=c("aut", "cre"), 
                 email = "grimbough@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Rarr 1.9.2
+
+* `writeZarrArray()` now allows writing character arrays, and no longer error 
+  complaining about missing 'nchar' argument value.
+
 # Rarr 1.9
 
 * Updated `.url_parse_other()` to account for port numbers in host name and 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # Rarr 1.9.2
 
 * `writeZarrArray()` now allows writing character arrays, and no longer error 
-  complaining about missing 'nchar' argument value.
+  complaining about null 'nchar' argument value. Default of 'nchar' is now
+  `NULL`.
 
 # Rarr 1.9
 

--- a/R/writeZarrArray.R
+++ b/R/writeZarrArray.R
@@ -54,7 +54,8 @@ setMethod("chunkdim", "ZarrRealizationSink", function(x) x@chunk_dim)
 ZarrRealizationSink <- function(zarr_array_path = NULL, 
                                 dim, 
                                 type="double",
-                                chunkdim = NULL) {
+                                chunkdim = NULL, 
+                                nchar = NULL) {
 
   if (is.null(zarr_array_path)) {
     stop('must provide a path')
@@ -69,7 +70,7 @@ ZarrRealizationSink <- function(zarr_array_path = NULL,
   }
   
   create_empty_zarr_array(zarr_array_path, dim = dim, chunk_dim = chunkdim,
-                          data_type = type)
+                          data_type = type, nchar = nchar)
 
   new("ZarrRealizationSink", 
       dim = dim, 
@@ -90,11 +91,12 @@ setMethod("write_block", "ZarrRealizationSink", function(sink, viewport, block) 
 
 #' @export
 writeZarrArray <- function(x, zarr_array_path,
-                           chunk_dim = NULL) {
+                           chunk_dim = NULL, 
+                           nchar = NULL) {
   
   sink <- ZarrRealizationSink(zarr_array_path = zarr_array_path,
                               dim = dim(x), type = type(x),
-                              chunkdim = chunk_dim)
+                              chunkdim = chunk_dim, nchar = nchar)
   sink <- BLOCK_write_to_sink(sink, x)
   as(sink, "ZarrArray")
 }

--- a/R/writeZarrArray.R
+++ b/R/writeZarrArray.R
@@ -94,6 +94,10 @@ writeZarrArray <- function(x, zarr_array_path,
                            chunk_dim = NULL, 
                            nchar = NULL) {
   
+  if (storage.mode(x) == "character" && is.null(nchar)) {
+    nchar <- max(base::nchar(x))
+  }
+  
   sink <- ZarrRealizationSink(zarr_array_path = zarr_array_path,
                               dim = dim(x), type = type(x),
                               chunkdim = chunk_dim, nchar = nchar)

--- a/R/write_data.R
+++ b/R/write_data.R
@@ -33,7 +33,8 @@
 
   if (data_type %in% c("|S", "<U", ">U")) {
     if (is.null(nchar) || nchar < 1) {
-      stop("The 'nchar' argument must be provided and be a positive integer")
+      stop("The 'nchar' argument must be provided when working with ",
+           "character data types and be a positive integer")
     }
     data_type <- paste0(data_type, as.integer(nchar))
   }
@@ -88,7 +89,8 @@
 #' @export
 create_empty_zarr_array <- function(zarr_array_path, dim, chunk_dim, data_type,
                                     order = "F",
-                                    compressor = use_zlib(), fill_value, nchar,
+                                    compressor = use_zlib(), fill_value, 
+                                    nchar = NULL,
                                     dimension_separator = ".") {
   path <- .normalize_array_path(zarr_array_path)
   if (!dir.exists(path)) {

--- a/R/write_data.R
+++ b/R/write_data.R
@@ -32,7 +32,7 @@
   }
 
   if (data_type %in% c("|S", "<U", ">U")) {
-    if (missing(nchar) || nchar < 1) {
+    if (is.null(nchar) || missing(nchar) || nchar < 1) {
       stop("The 'nchar' argument must be provided and be a positive integer")
     }
     data_type <- paste0(data_type, as.integer(nchar))

--- a/R/write_data.R
+++ b/R/write_data.R
@@ -1,4 +1,4 @@
-.check_datatype <- function(data_type, fill_value, nchar) {
+.check_datatype <- function(data_type, fill_value, nchar = NULL) {
   if (missing(data_type) && missing(fill_value)) {
     stop("Data type cannot be determined if both 'data_type' and 'fill_value' arguments are missing.")
   } else if (missing(data_type) && !missing(fill_value)) {
@@ -32,7 +32,7 @@
   }
 
   if (data_type %in% c("|S", "<U", ">U")) {
-    if (is.null(nchar) || missing(nchar) || nchar < 1) {
+    if (is.null(nchar) || nchar < 1) {
       stop("The 'nchar' argument must be provided and be a positive integer")
     }
     data_type <- paste0(data_type, as.integer(nchar))

--- a/inst/tinytest/test_ZarrArray-class.R
+++ b/inst/tinytest/test_ZarrArray-class.R
@@ -16,3 +16,13 @@ expect_equal(path(z1), Rarr:::.normalize_array_path(tf1))
 # ways to get the array from disk to memory
 expect_equal(extract_array(z1, index = list(NULL, NULL)), m)
 expect_equal(realize(z1, BACKEND = NULL), m)
+
+# create ZarrArray with character data type
+m <- matrix("array", ncol = 10, nrow = 10)
+tf2 <- tempfile(fileext = ".zarr")
+chunk_dim <- c(10,10)
+z2 <- writeZarrArray(m, tf2, chunk_dim = chunk_dim)
+
+expect_inherits(z2, class = "ZarrArray")
+
+expect_equal(type(z2), "character")

--- a/inst/tinytest/test_string.R
+++ b/inst/tinytest/test_string.R
@@ -47,6 +47,16 @@ expect_silent(
 )
 expect_equal(max(nchar(read_zarr_array(path))), 1L)
 
+## check if nchar argument is provided when creating empty character zarr arrays
+path <- tempfile()
+expect_error(
+  create_empty_zarr_array(zarr_array_path = path, 
+                          dim = dim(column_major), 
+                          chunk_dim = c(2, 5, 1), 
+                          data_type = storage.mode(column_major)
+  )
+)
+
 ########################
 
 greetings <- c('¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', 'Hei maailma!',


### PR DESCRIPTION
Missing `nchar` gives error with text array

```
> mat <- array(rep("text",231145), dim = c(231145))
> path_to_new_zarr <- file.path("data/string_test.zarr")
> writeZarrArray(x = mat, zarr_array_path = path_to_new_zarr, chunk_dim = c(10000))
Error in .check_datatype(data_type = data_type, fill_value = fill_value,  : 
  The 'nchar' argument must be provided and be a positive integer
```

however now (more in #16).

```
> writeZarrArray(x = mat, zarr_array_path = path_to_new_zarr, chunk_dim = c(10000), nchar = 4)
<231145> ZarrArray object of type "character":
[1]      [2]      [3]      .        [231144] [231145] 
  "text"   "text"   "text"        .       ""       "" 
```
