### PR TITLE
Take port into account, allow colons in bucket names when parsing urls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 1.9.0
+Version: 1.9.1
 Authors@R: c(person("Mike", "Smith", 
                 role=c("aut", "cre"), 
                 email = "grimbough@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Rarr 1.9
+
+* Updated `.url_parse_other()` to account for port numbers in host name and 
+  colons in bucket.
+
 # Rarr 1.7
 
 * Added `path()` method for `ZarrArray` class that returns the location of the

--- a/R/s3.R
+++ b/R/s3.R
@@ -74,15 +74,20 @@ parse_s3_path <- function(path) {
 #' @keywords Internal
 .url_parse_other <- function(url) {
   parsed_url <- httr::parse_url(url)
-  bucket <- gsub(x = parsed_url$path, pattern = "^/?([[a-z0-9\\.-]*)/.*", 
+  bucket <- gsub(x = parsed_url$path, pattern = "^/?([[a-z0-9\\:\\.-]*)/.*", 
                  replacement = "\\1", ignore.case = TRUE)
-  object <- gsub(x = parsed_url$path, pattern = "^/?([a-z0-9\\.-]*)/(.*)", 
+  object <- gsub(x = parsed_url$path, pattern = "^/?([a-z0-9\\:\\.-]*)/(.*)", 
                  replacement = "\\2", ignore.case = TRUE)
-  
-  res <- list(bucket = bucket, 
-              object = object, 
-              region = "auto", 
-              hostname = paste0(parsed_url$scheme, "://", parsed_url$hostname))
+  hostname <- paste0(parsed_url$scheme, "://", parsed_url$hostname)
+
+  if (!is.null(parsed_url$port)) {
+    hostname <- paste0(hostname, ":", parsed_url$port)
+  }
+
+  res <- list(bucket = bucket,
+              object = object,
+              region = "auto",
+              hostname = hostname)
   return(res)
 }
 

--- a/R/s3.R
+++ b/R/s3.R
@@ -74,9 +74,9 @@ parse_s3_path <- function(path) {
 #' @keywords Internal
 .url_parse_other <- function(url) {
   parsed_url <- httr::parse_url(url)
-  bucket <- gsub(x = parsed_url$path, pattern = "^/?([[a-z0-9\\:\\.-]*)/.*", 
+  bucket <- gsub(x = parsed_url$path, pattern = "^/?([[a-z0-9:\\.-]*)/.*",
                  replacement = "\\1", ignore.case = TRUE)
-  object <- gsub(x = parsed_url$path, pattern = "^/?([a-z0-9\\:\\.-]*)/(.*)", 
+  object <- gsub(x = parsed_url$path, pattern = "^/?([a-z0-9:\\.-]*)/(.*)",
                  replacement = "\\2", ignore.case = TRUE)
   hostname <- paste0(parsed_url$scheme, "://", parsed_url$hostname)
 

--- a/inst/tinytest/test_url_parsing.R
+++ b/inst/tinytest/test_url_parsing.R
@@ -3,8 +3,10 @@ paths <- list(
   aws_host =  "https://DOC-EXAMPLE-BUCKET1.s3.us-west-2.amazonaws.com/puppy.png",
   aws_path =  "https://s3.us-west-2.amazonaws.com/DOC-EXAMPLE-BUCKET1/puppy.png",
   #embl_host = "https://rarr-testing.s3.embl.de/bz2.zarr/.zarray",
-  embl_path = "https://s3.embl.de/rarr-testing/bz2.zarr/.zarray"
-  
+  embl_path = "https://s3.embl.de/rarr-testing/bz2.zarr/.zarray",
+  eopf_path_1 = "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/",
+  eopf_path_2 = "https://objects.eodc.eu:443/e05ab01a9d56408d82ac32d69a5aae2a:202506-s01siwgrh/03/products/cpm_v256/S1C_IW_GRDH_1SDV_20250603T053151_20250603T053216_002614_0056AB_EE86.zarr"
+
 )
 
 for(i in which(grepl("aws", names(paths))) ) {
@@ -23,7 +25,24 @@ for(i in which(grepl("embl", names(paths))) ) {
   expect_equal(parsed$region,   "auto")
 }
 
+for(i in which(grepl("eopf_path_1", names(paths))) ) {
+  expect_silent(parsed <- .url_parse_other(paths[[ i ]]))
+  expect_equal(parsed$bucket,   "e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a")
+  expect_equal(parsed$hostname, "https://objectstore.eodc.eu:2222")
+  expect_equal(parsed$object,   "17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/")
+  expect_equal(parsed$region,   "auto")
+}
+
+for(i in which(grepl("eopf_path_2", names(paths))) ) {
+  expect_silent(parsed <- .url_parse_other(paths[[ i ]]))
+  expect_equal(parsed$bucket,   "e05ab01a9d56408d82ac32d69a5aae2a:202506-s01siwgrh")
+  expect_equal(parsed$hostname, "https://objects.eodc.eu:443")
+  expect_equal(parsed$object,   "03/products/cpm_v256/S1C_IW_GRDH_1SDV_20250603T053151_20250603T053216_002614_0056AB_EE86.zarr")
+  expect_equal(parsed$region,   "auto")
+}
 
 expect_identical(Rarr:::.determine_s3_provider(paths[["aws_host"]]),  "aws")
 expect_identical(Rarr:::.determine_s3_provider(paths[["embl_path"]]), "other")
 expect_identical(Rarr:::.determine_s3_provider("https://foo.bar/baz"), "other")
+expect_identical(Rarr:::.determine_s3_provider(paths[["eopf_path_1"]]), "other")
+expect_identical(Rarr:::.determine_s3_provider(paths[["eopf_path_2"]]), "other")

--- a/inst/tinytest/test_url_parsing.R
+++ b/inst/tinytest/test_url_parsing.R
@@ -26,7 +26,7 @@ for(i in which(grepl("embl", names(paths))) ) {
 }
 
 for(i in which(grepl("eopf_path_1", names(paths))) ) {
-  expect_silent(parsed <- .url_parse_other(paths[[ i ]]))
+  expect_silent(parsed <- Rarr:::.url_parse_other(paths[[ i ]]))
   expect_equal(parsed$bucket,   "e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a")
   expect_equal(parsed$hostname, "https://objectstore.eodc.eu:2222")
   expect_equal(parsed$object,   "17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/")
@@ -34,7 +34,7 @@ for(i in which(grepl("eopf_path_1", names(paths))) ) {
 }
 
 for(i in which(grepl("eopf_path_2", names(paths))) ) {
-  expect_silent(parsed <- .url_parse_other(paths[[ i ]]))
+  expect_silent(parsed <- Rarr:::.url_parse_other(paths[[ i ]]))
   expect_equal(parsed$bucket,   "e05ab01a9d56408d82ac32d69a5aae2a:202506-s01siwgrh")
   expect_equal(parsed$hostname, "https://objects.eodc.eu:443")
   expect_equal(parsed$object,   "03/products/cpm_v256/S1C_IW_GRDH_1SDV_20250603T053151_20250603T053216_002614_0056AB_EE86.zarr")


### PR DESCRIPTION
Hi there,

I'm working with S3 data that isn't properly supported by the current URL parsing in `.url_parse_other()`; namely, there is a port that needs to be sent along with the hostname, and a colon in the bucket name: e.g., `"https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"`.

With the current code in this function, the URL is not parsed properly and it causes `zarr_overview()` etc to time out, because it tries to reach `"https://objectstore.eodc.eu/..."` instead of `"https://objectstore.eodc.eu:2222/..."` (plus the bucket and key aren't parsed right when it doesn't consider the `:` in bucket):

``` r
url <- "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"

Rarr:::.url_parse_other(url)
#> $bucket
#> [1] "e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"
#> 
#> $object
#> [1] "e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"
#> 
#> $region
#> [1] "auto"
#> 
#> $hostname
#> [1] "https://objectstore.eodc.eu"
Rarr::zarr_overview(url)
#> Error in `req_perform()`:
#> ! Failed to perform HTTP request.
#> Caused by error in `curl::curl_fetch_memory()`:
#> ! Timeout was reached [objectstore.eodc.eu]: Connection timed out after 60002 milliseconds
```

This PR updates `.url_parse_other()` so that the port is considered, and colons are allowed in the bucket:

``` r
url <- "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"

.url_parse_other <- function(url) {
  parsed_url <- httr::parse_url(url)
  bucket <- gsub(x = parsed_url$path, pattern = "^/?([[a-z0-9\\:\\.-]*)/.*",
                 replacement = "\\1", ignore.case = TRUE)
  object <- gsub(x = parsed_url$path, pattern = "^/?([a-z0-9\\:\\.-]*)/(.*)",
                 replacement = "\\2", ignore.case = TRUE)
  hostname <- paste0(parsed_url$scheme, "://", parsed_url$hostname)

  if (!is.null(parsed_url$port)) {
    hostname <- paste0(hostname, ":", parsed_url$port)
  }

  res <- list(bucket = bucket,
              object = object,
              region = "auto",
              hostname = hostname)
  return(res)
}

.url_parse_other(url)
#> $bucket
#> [1] "e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a"
#> 
#> $object
#> [1] "17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/"
#> 
#> $region
#> [1] "auto"
#> 
#> $hostname
#> [1] "https://objectstore.eodc.eu:2222"

assignInNamespace(".url_parse_other", .url_parse_other, ns = "Rarr")

Rarr::zarr_overview(url)
#> Type: Group of Arrays
#> Path: https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/17/products/cpm_v256/S2A_MSIL2A_20250517T085541_N0511_R064_T35QKA_20250517T112203.zarr/
#> Arrays:
#> ---
#>   Path: conditions/geometry/angle
#>   Shape: 2
#>   Chunk Shape: 2
#>   No. of Chunks: 1 (1)
#>   Data Type: unicode224
#>   Endianness: little
#>   Compressor: blosc
#> ---
```
(output shortened, just showing it works)

Let me know if anything looks off about this or if you have any questions. Thank you!
