### PR TITLE
Use readBin() on a connection

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -144,9 +144,7 @@ check_index <- function(index, metadata) {
   output <- character(length = nvalues)
   for (i in seq_len(nvalues)) {
     nbytes <- readBin(con, what = "integer", n = 1, size = 4)
-    if (nbytes > 0) {
-      output[i] <- readChar(con, nchars = nbytes, useBytes = TRUE)
-    }
+    output[i] <- readChar(con, nchars = nbytes, useBytes = TRUE)
   }
 
   Encoding(output) <- "UTF-8"

--- a/R/utils.R
+++ b/R/utils.R
@@ -138,15 +138,14 @@ check_index <- function(index, metadata) {
 }
 
 .readVlenUTF8 <- function(input) {
-  nvalues <- readBin(input, what = "integer", n = 1, size = 4)
+  con <- rawConnection(input)
+  on.exit(close(con))
+  nvalues <- readBin(con, what = "integer", n = 1, size = 4)
   output <- character(length = nvalues)
-  input <- tail(input, -4)
   for (i in seq_len(nvalues)) {
-    nbytes <- readBin(input, what = "integer", n = 1, size = 4)
-    input <- tail(input, -4)
+    nbytes <- readBin(con, what = "integer", n = 1, size = 4)
     if (nbytes > 0) {
-      output[i] <- rawToChar(input[seq_len(nbytes)])
-      input <- tail(input, -nbytes)
+      output[i] <- readChar(con, nchars = nbytes, useBytes = TRUE)
     }
   }
 


### PR DESCRIPTION
to avoid having to manually move the cursor