### PR TITLE
Move table of supported feature to a dedicated vignette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ README_cache
 ## html
 inst/**/*.html
 docs
+inst/doc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     BiocStyle,
     covr,
     knitr,
+    rmarkdown,
     testthat (>= 3.0.0),
     withr
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 1.11.0
+Version: 1.11.1
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# Rarr 1.11
+
+## Minor improvements
+
+* There is now a dedicated vignette describing the supported Zarr features
+  in Rarr, available at
+  <https://huber-group-embl.github.io/Rarr/articles/features.html>.
+  This makes it more easily discoverable on the Bioconductor landing page.
+
 # Rarr 1.9
 
 ## New features

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,70 +48,15 @@ instances e.g. 64-bit integers there is potential for loss of information.
 Writing is more limited with support only for datatypes that are supported
 natively in R and only using the column-first representation.
 
+See the dedicated ["Supported Zarr features" vignette](https://huber-group-embl.github.io/Rarr/articles/features.html) for more information.
+
 # Quick start guide
 
 ```{r, child=c('inst/rmd/quick_start.Rmd')}
 ```
-
-
-# Current Status
-
-## Reading and Writing
-
-Reading Zarr arrays is reasonably well supported. Writing is available, but is more limited.  Both aspects are under active development.
-
-### Data Types
-
-Currently there is only support for reading and writing a subset of the possible datatypes
-that can be found in a Zarr array.  In some instances there are also limitations on the
-datatypes natively supported by R, requiring conversion from the Zarr datatype.  The table below summarises the current status of
-datatype support.  It will be updated as progress is made.
-
-| Zarr Data Type | Status<br/>(reading / writing) | Notes |
-|-----------|:--------------:|-------|
-|`boolean`  | &#x2714; / &#x274C; | |
-|`int8`     | &#x2714; / &#x274C; | |
-|`uint8` | &#x2714; / &#x274C; | |
-|`int16` | &#x2714; / &#x274C; | |
-|`uint16`| &#x2714; / &#x274C; | |
-|`int32` | &#x2714; / &#x2714; | |
-|`uint32`| &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`.  Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-|`int64` | &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-|`uint64`| &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-|`half` / `float16`   | &#x2714; / &#x274C; | Converted to `double` in R.  No effort is made to assess loss of precision due to conversion.  |
-|`single` / `float32` | &#x2714; / &#x274C; | Converted to `double` in R.  No effort is made to assess loss of precision due to conversion. |
-|`double` / `float64` | &#x2714; / &#x2714; | |
-|`complex`            | &#x274C; / &#x274C; | |
-|`timedelta`          | &#x274C; / &#x274C; | |
-|`datetime`           | &#x274C; / &#x274C; | |
-|`string`             | &#x2714; / &#x2714; | |
-|`Unicode`            | &#x2714; / &#x2714; | |
-|`void *`             | &#x274C; / &#x274C; | |
-| Structured data types | &#x274C; / &#x274C; | |
-
-### Compression Tools
-
-| Data Type   | Status<br/>(reading / writing) | Notes |
-|-------------|:-------------------:|-------|
-|`zlib / gzip`| &#x2714; / &#x2714; | Only system default compression level (normally 6) is enabled for writing. |
-|`bzip2`      | &#x2714; / &#x2714; | Only compression level 9 is enabled for writing. |
-|`blosc`      | &#x2714; / &#x2714; | Only `lz4` compression level 5 is enabled for writing. |
-|`LZMA `      | &#x2714; / &#x2714; | |
-|`LZ4`        | &#x2714; / &#x2714; | |
-|`Zstd`       | &#x2714; / &#x2714; | |
-
-Please open an [issue](https://github.com/grimbough/Rarr/issues) if support for a required compression tool is missing.
-
-### Filters
-
-The is currently no support for additional filters.  Please open an [issue](https://github.com/grimbough/Rarr/issues) if you require filter support.
 
 # Required system libraries
 
 To provide support for BLOSC and zstd compression tools Rarr links against libraries providing these tools.  If you have them installed on your system Rarr will attempt to use those versions.  If they are not detected then Rarr will compile and use versions that are distributed with the package.  Either way the functionality will available, however if you are using the system libraries and then later remove them Rarr may fail to work correctly.
 
 This only concerns users installing the package from source. If you are using the pre-built binaries for Windows or Mac OSX distributed by Bioconductor then this should not be an issue for you.
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Mike L. Smith
     array](#reading-a-from-a-local-zarr-array)
   - [Reading from S3 storage](#read-s3)
   - [Writing to a Zarr array](#writing-to-a-zarr-array)
-- [Current Status](#current-status)
-  - [Reading and Writing](#reading-and-writing)
 - [Required system libraries](#required-system-libraries)
 
 <!-- badges: start -->
@@ -57,6 +55,10 @@ although in some instances e.g. 64-bit integers there is potential for
 loss of information. Writing is more limited with support only for
 datatypes that are supported natively in R and only using the
 column-first representation.
+
+See the dedicated [“Supported Zarr features”
+vignette](https://huber-group-embl.github.io/Rarr/articles/features.html)
+for more information.
 
 # Quick start guide
 
@@ -105,7 +107,7 @@ zarr_overview(zarr_example)
 ```
 
     ## Type: Array
-    ## Path: /tmp/RtmpF7Gmri/temp_libpath200434430aca/Rarr/extdata/zarr_examples/column-first/int32.zarr
+    ## Path: /tmp/RtmpD8R4Xh/temp_libpath182f36cf721d9/Rarr/extdata/zarr_examples/column-first/int32.zarr
     ## Shape: 30 x 20 x 10
     ## Chunk Shape: 10 x 10 x 5
     ## No. of Chunks: 12 (3 x 2 x 2)
@@ -140,7 +142,7 @@ read_zarr_array(zarr_example, index = index)
 ```
 
     ## , , 1
-    ##
+    ## 
     ##      [,1] [,2]
     ## [1,]    1    2
     ## [2,]    1    0
@@ -159,7 +161,7 @@ zarr_overview(s3_address)
 ```
 
     ## Type: Array
-    ## Path: https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr/0/
+    ## Path: https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr/0
     ## Shape: 50 x 494 x 464
     ## Chunk Shape: 1 x 494 x 464
     ## No. of Chunks: 50 (50 x 1 x 1)
@@ -232,7 +234,7 @@ read_zarr_array(zarr_array_path = path_to_new_zarr, index = list(6:10, 10, 1))
 ```
 
     ## , , 1
-    ##
+    ## 
     ##      [,1]
     ## [1,]   96
     ## [2,]   97
@@ -245,64 +247,6 @@ identical(read_zarr_array(zarr_array_path = path_to_new_zarr), x)
 ```
 
     ## [1] TRUE
-
-# Current Status
-
-## Reading and Writing
-
-Reading Zarr arrays is reasonably well supported. Writing is available,
-but is more limited. Both aspects are under active development.
-
-### Data Types
-
-Currently there is only support for reading and writing a subset of the
-possible datatypes that can be found in a Zarr array. In some instances
-there are also limitations on the datatypes natively supported by R,
-requiring conversion from the Zarr datatype. The table below summarises
-the current status of datatype support. It will be updated as progress
-is made.
-
-| Zarr Data Type | Status<br/>(reading / writing) | Notes |
-|----|:--:|----|
-| `boolean` | ✔ / ❌ |  |
-| `int8` | ✔ / ❌ |  |
-| `uint8` | ✔ / ❌ |  |
-| `int16` | ✔ / ❌ |  |
-| `uint16` | ✔ / ❌ |  |
-| `int32` | ✔ / ✔ |  |
-| `uint32` | ✔ / ❌ | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-| `int64` | ✔ / ❌ | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-| `uint64` | ✔ / ❌ | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
-| `half` / `float16` | ✔ / ❌ | Converted to `double` in R. No effort is made to assess loss of precision due to conversion. |
-| `single` / `float32` | ✔ / ❌ | Converted to `double` in R. No effort is made to assess loss of precision due to conversion. |
-| `double` / `float64` | ✔ / ✔ |  |
-| `complex` | ❌ / ❌ |  |
-| `timedelta` | ❌ / ❌ |  |
-| `datetime` | ❌ / ❌ |  |
-| `string` | ✔ / ✔ |  |
-| `Unicode` | ✔ / ✔ |  |
-| `void *` | ❌ / ❌ |  |
-| Structured data types | ❌ / ❌ |  |
-
-### Compression Tools
-
-| Data Type | Status<br/>(reading / writing) | Notes |
-|----|:--:|----|
-| `zlib / gzip` | ✔ / ✔ | Only system default compression level (normally 6) is enabled for writing. |
-| `bzip2` | ✔ / ✔ | Only compression level 9 is enabled for writing. |
-| `blosc` | ✔ / ✔ | Only `lz4` compression level 5 is enabled for writing. |
-| `LZMA` | ✔ / ✔ |  |
-| `LZ4` | ✔ / ✔ |  |
-| `Zstd` | ✔ / ✔ |  |
-
-Please open an [issue](https://github.com/grimbough/Rarr/issues) if
-support for a required compression tool is missing.
-
-### Filters
-
-The is currently no support for additional filters. Please open an
-[issue](https://github.com/grimbough/Rarr/issues) if you require filter
-support.
 
 # Required system libraries
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,0 +1,4 @@
+*.html
+*.R
+
+/.quarto/

--- a/vignettes/Rarr.Rmd
+++ b/vignettes/Rarr.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Reading Zarr arrays with Rarr"
+title: "Working with Zarr arrays in R"
 date: "`r BiocStyle::doc_date()`"
 author:
   - name: Mike L. Smith

--- a/vignettes/features.Rmd
+++ b/vignettes/features.Rmd
@@ -1,0 +1,79 @@
+---
+title: "Supported Zarr features in Rarr"
+date: "`r BiocStyle::doc_date()`"
+package: "`r BiocStyle::pkg_ver('Rarr')`"
+vignette: >
+  %\VignetteIndexEntry{"Supported Zarr features in Rarr"}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+output:
+  BiocStyle::html_document
+---
+
+```{css, echo=FALSE}
+.main-container {
+  max-width: 1600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+```
+
+## Zarr version
+
+Rarr currently only works with [Zarr specification version 2](https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html).
+Support for [version 3](https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html) is actively being worked on.
+
+## Reading and Writing
+
+Reading Zarr arrays is reasonably well supported. Writing is available, but is more limited.  Both aspects are under active development.
+
+### Data Types
+
+Currently there is only support for reading and writing a subset of the possible datatypes
+that can be found in a Zarr array.  In some instances there are also limitations on the
+datatypes natively supported by R, requiring conversion from the Zarr datatype.  The table below summarises the current status of
+datatype support.  It will be updated as progress is made.
+
+| Zarr Data Type | Status<br/>(reading / writing) | Notes |
+|-----------|:--------------:|-------|
+|`boolean`  | &#x2714; / &#x274C; | |
+|`int8`     | &#x2714; / &#x274C; | |
+|`uint8` | &#x2714; / &#x274C; | |
+|`int16` | &#x2714; / &#x274C; | |
+|`uint16`| &#x2714; / &#x274C; | |
+|`int32` | &#x2714; / &#x2714; | |
+|`uint32`| &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`.  Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
+|`int64` | &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
+|`uint64`| &#x2714; / &#x274C; | Values outside the range of `int32` are converted to `NA`. Future plan is to allow conversion to `double` or use the [bit64](https://cran.r-project.org/package=bit64) package. |
+|`half` / `float16`   | &#x2714; / &#x274C; | Converted to `double` in R.  No effort is made to assess loss of precision due to conversion.  |
+|`single` / `float32` | &#x2714; / &#x274C; | Converted to `double` in R.  No effort is made to assess loss of precision due to conversion. |
+|`double` / `float64` | &#x2714; / &#x2714; | |
+|`complex`            | &#x274C; / &#x274C; | |
+|`timedelta`          | &#x274C; / &#x274C; | |
+|`datetime`           | &#x274C; / &#x274C; | |
+|`string`             | &#x2714; / &#x2714; | |
+|`Unicode`            | &#x2714; / &#x2714; | |
+|`void *`             | &#x274C; / &#x274C; | |
+| Structured data types | &#x274C; / &#x274C; | |
+
+### Codecs
+
+#### Compression codecs
+
+| Data Type   | Status<br/>(reading / writing) | Notes |
+|-------------|:-------------------:|-------|
+|`zlib / gzip`| &#x2714; / &#x2714; | Only system default compression level (normally 6) is enabled for writing. |
+|`bzip2`      | &#x2714; / &#x2714; | Only compression level 9 is enabled for writing. |
+|`blosc`      | &#x2714; / &#x2714; | Only `lz4` compression level 5 is enabled for writing. |
+|`LZMA `      | &#x2714; / &#x2714; | |
+|`LZ4`        | &#x2714; / &#x2714; | |
+|`Zstd`       | &#x2714; / &#x2714; | |
+
+Please open an [issue](https://github.com/Huber-group-EMBL/Rarr/issues) if support for a required compression codec is missing.
+
+#### Other codecs
+
+| Codec     | Status<br/>(reading / writing) | Notes |
+|-----------|:------------------------------:|-------|
+|`endian`   | &#x2714; / &#x274C;            |       |
+|`transpose`| &#x2714; / &#x2714;            | Only the simple T/C case defined in v2 |


### PR DESCRIPTION
So that it's more easily findable on the Bioconductor landing page