### PR TITLE
Convert `fill_value` for string `dtype`s

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 1.11.15
+Version: 1.11.16
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,9 @@
 * `zarr_overview()` no longer fails on consolidated metadata containing uncompressed
   arrays. This was introduced in https://github.com/Huber-group-EMBL/Rarr/pull/45.
   Thanks to Sharla Gelfand for reporting the issue and providing test data. 
+* the `fill_value` is now correctly interpreted when reading Zarr v2 string or 
+  unicode arrays. This is visible for example when trying to read missing chunks
+  from such arrays. Thanks to Artür Manukyan for the bug report.
 
 ## Internal changes
 

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -379,6 +379,8 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
       "int" = as.integer(val),
       "uint" = as.integer(val),
       "complex" = as.complex(val),
+      "string" = as.character(val),
+      "unicode" = as.character(val),
       val
     )
   }

--- a/tests/testthat/test-string.R
+++ b/tests/testthat/test-string.R
@@ -173,3 +173,19 @@ test_that("v2 and v3 return identical results", {
 
   expect_identical(vlen_utf8_v2, vlen_utf8_v3)
 })
+
+test_that("fill_value is converted to string", {
+  # https://github.com/Huber-group-EMBL/Rarr/issues/94
+  path <- withr::local_tempfile(fileext = ".zarr")
+  expect_silent(
+    create_empty_zarr_array(
+      zarr_array_path = path,
+      dim = c(4, 4),
+      chunk_dim = c(2, 2),
+      data_type = "character",
+      fill_value = 0,
+      nchar = 10
+    )
+  )
+  expect_identical(read_zarr_array(path), matrix("0", nrow = 4, ncol = 4))
+})


### PR DESCRIPTION
Fix #94.