### PR TITLE
add s3_client check to read_zarr_attributes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 1.11.17
+Version: 1.11.18
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
   * float32 / single
 * Scalar arrays (i.e., arrays with zero dimensions) can now be read.
   Thanks to Artür Manukyan for the bug report.
+* Zarr attributes can now be read by passing an s3 URL directly as
+  the first argument of `read_zarr_attributes()`. This makes 
+  `read_zarr_attributes()` consistent with `read_zarr_array()` and
+  `zarr_overview()`.
 
 ## Minor improvements
 

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -443,7 +443,11 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
 #' @export
 read_zarr_attributes <- function(zarr_path, s3_client = NULL) {
   zarr_path <- .normalize_array_path(zarr_path)
-
+  ## determine if this is a local or S3 array
+  if (missing(s3_client)) {
+    s3_client <- .create_s3_client(path = zarr_path)
+  }
+  
   exists_attribute_files <- .file_or_blob_exists(
     zarr_path,
     s3_client,

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -447,7 +447,7 @@ read_zarr_attributes <- function(zarr_path, s3_client = NULL) {
   if (missing(s3_client)) {
     s3_client <- .create_s3_client(path = zarr_path)
   }
-  
+
   exists_attribute_files <- .file_or_blob_exists(
     zarr_path,
     s3_client,

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -441,7 +441,7 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
 #' @importFrom jsonlite read_json fromJSON
 #'
 #' @export
-read_zarr_attributes <- function(zarr_path, s3_client = NULL) {
+read_zarr_attributes <- function(zarr_path, s3_client) {
   zarr_path <- .normalize_array_path(zarr_path)
   ## determine if this is a local or S3 array
   if (missing(s3_client)) {

--- a/man/read_zarr_attributes.Rd
+++ b/man/read_zarr_attributes.Rd
@@ -4,7 +4,7 @@
 \alias{read_zarr_attributes}
 \title{Read the attributes associated with a Zarr array or group}
 \usage{
-read_zarr_attributes(zarr_path, s3_client = NULL)
+read_zarr_attributes(zarr_path, s3_client)
 }
 \arguments{
 \item{zarr_path}{A character vector of length 1.  This provides the

--- a/tests/testthat/_snaps/attributes.md
+++ b/tests/testthat/_snaps/attributes.md
@@ -2,3 +2,53 @@
 
     The path contains both `.zattrs` (v2 Zarr specification) and `zarr.json` (v3 Zarr specification) files, which is not allowed.
 
+# read_zarr_attributes from s3
+
+    Code
+      read_zarr_attributes(
+        "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/")
+    Output
+      $`_creator`
+      $`_creator`$name
+      [1] "omero-zarr"
+      
+      $`_creator`$version
+      [1] "0.1.dev219+g541c88e"
+      
+      
+      $multiscales
+           axes     datasets version
+      1 c, y, x c("0", "....     0.3
+      
+      $omero
+      $omero$channels
+        active coefficient  color family inverted   label window.end window.max
+      1   TRUE           1 FF0000 linear    FALSE Cam2-T1       5090      65535
+      2   TRUE           1 00C000 linear    FALSE Cam1-T2       5736      65535
+      3   TRUE           1 FFFFFF linear    FALSE       2       5312      65535
+      4  FALSE           1 FFFFFF linear    FALSE       3       4128      65535
+        window.min window.start
+      1          0          198
+      2          0          198
+      3          0          196
+      4          0          194
+      
+      $omero$id
+      [1] 1
+      
+      $omero$rdefs
+      $omero$rdefs$defaultT
+      [1] 0
+      
+      $omero$rdefs$defaultZ
+      [1] 0
+      
+      $omero$rdefs$model
+      [1] "color"
+      
+      
+      $omero$version
+      [1] "0.3"
+      
+      
+

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -151,3 +151,11 @@ test_that("read_zarr_attributes errors clearly for invalid mixed arrays", {
     read_zarr_attributes(invalid_zarr)
   )
 })
+
+test_that("read_zarr_attributes from s3", {
+  expect_true(
+    is.list(
+      read_zarr_attributes("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/")
+    )
+  )
+})

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -153,11 +153,9 @@ test_that("read_zarr_attributes errors clearly for invalid mixed arrays", {
 })
 
 test_that("read_zarr_attributes from s3", {
-  expect_true(
-    is.list(
-      read_zarr_attributes(
-        "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/"
-      )
+  expect_snapshot(
+    read_zarr_attributes(
+      "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/"
     )
   )
 })

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -155,7 +155,9 @@ test_that("read_zarr_attributes errors clearly for invalid mixed arrays", {
 test_that("read_zarr_attributes from s3", {
   expect_true(
     is.list(
-      read_zarr_attributes("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/")
+      read_zarr_attributes(
+        "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr/"
+      )
     )
   )
 })


### PR DESCRIPTION
Probably the zarr in the test should be replaced but I couldn't locate a remote zarr with attributes under testthat. 