### PR TITLE
Fix build on R < 4.6

### DIFF
--- a/src/Rarr.h
+++ b/src/Rarr.h
@@ -4,7 +4,14 @@
 #include <R.h>
 #include <Rdefines.h>
 #include <Rinternals.h>
+#include <Rversion.h> 
 #include <stdint.h>
 #include <stddef.h>
+  
+/* From https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports-1 */
+#if R_VERSION < R_Version(4, 6, 0)
+SEXP R_allocResizableVector(SEXPTYPE type, R_xlen_t maxlen);
+#define R_resizeVector SET_LENGTH
+#endif
 
 #endif

--- a/src/compress.c
+++ b/src/compress.c
@@ -90,3 +90,13 @@ SEXP compress_chunk_ZSTD(SEXP input, SEXP compression_level) {
   UNPROTECT(1);
   return output;
 } 
+
+/* From https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports-1 */
+#if R_VERSION < R_Version(4, 6, 0)
+SEXP R_allocResizableVector(SEXPTYPE type, R_xlen_t maxlen) {
+  SEXP ret = Rf_allocVector(type, maxlen);
+  SET_TRUELENGTH(ret, maxlen);
+  SET_GROWABLE_BIT(ret);
+  return ret;
+}
+#endif


### PR DESCRIPTION
I know this package is intended for bioc-devel/r-devel, but several components of R-universe run r-release to render things, so it would be nice if we can keep supporting that version too for now.

See section 6.22.8 from https://cran.r-project.org/doc/manuals/r-devel/R-exts.html 