### PR TITLE
Set s3_client default to NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 2.1.5
+Version: 2.1.6
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Rarr 2.1
 
+## Breaking changes
+
+* (Minor:) `s3_client =` argument default value in `read_zarr_array()`, 
+  `zarr_overview()`, etc. is now set to `NULL` instead of missing. In practice,
+  we expect this grant to be invisible to most users but it makes it easier
+  to pass down missing values in Rarr reverse dependencies.
+
 ## Minor improvements
 
 * `normalize_array_path()` has been slightly optimized for speed. It is not

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -40,10 +40,10 @@
 #' }
 #'
 #' @export
-read_zarr_array <- function(zarr_array_path, index, s3_client) {
+read_zarr_array <- function(zarr_array_path, index, s3_client = NULL) {
   zarr_array_path <- .normalize_array_path(zarr_array_path)
   ## determine if this is a local or S3 array
-  if (missing(s3_client)) {
+  if (is.null(s3_client)) {
     s3_client <- .create_s3_client(path = zarr_array_path)
   }
 

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -47,10 +47,14 @@
 #' zarr_overview(z2)
 #' }
 #' @export
-zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
+zarr_overview <- function(
+  zarr_array_path,
+  s3_client = NULL,
+  as_data_frame = FALSE
+) {
   zarr_array_path <- .normalize_array_path(zarr_array_path)
 
-  if (missing(s3_client)) {
+  if (is.null(s3_client)) {
     s3_client <- .create_s3_client(path = zarr_array_path)
   }
 
@@ -513,16 +517,21 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
 #'
 #' @importFrom jsonlite read_json fromJSON
 #'
+#' @examples
+#' read_zarr_attributes(
+#'   "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr"
+#' )
+#'
 #' @export
 read_zarr_attributes <- function(
   zarr_path,
-  s3_client,
+  s3_client = NULL,
   missing = c("ignore", "warning", "error")
 ) {
   missing <- match.arg(missing)
   zarr_path <- .normalize_array_path(zarr_path)
   ## determine if this is a local or S3 array
-  if (missing(s3_client)) {
+  if (is.null(s3_client)) {
     s3_client <- .create_s3_client(path = zarr_path)
   }
 

--- a/man/read_zarr_array.Rd
+++ b/man/read_zarr_array.Rd
@@ -4,7 +4,7 @@
 \alias{read_zarr_array}
 \title{Read a Zarr array}
 \usage{
-read_zarr_array(zarr_array_path, index, s3_client)
+read_zarr_array(zarr_array_path, index, s3_client = NULL)
 }
 \arguments{
 \item{zarr_array_path}{Path to a Zarr array. A character vector of length 1.

--- a/man/read_zarr_attributes.Rd
+++ b/man/read_zarr_attributes.Rd
@@ -6,7 +6,7 @@
 \usage{
 read_zarr_attributes(
   zarr_path,
-  s3_client,
+  s3_client = NULL,
   missing = c("ignore", "warning", "error")
 )
 }
@@ -33,4 +33,10 @@ are provided, an empty list is returned.
 }
 \description{
 Read the attributes associated with a Zarr array or group
+}
+\examples{
+read_zarr_attributes(
+  "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr"
+)
+
 }

--- a/man/zarr_overview.Rd
+++ b/man/zarr_overview.Rd
@@ -4,7 +4,7 @@
 \alias{zarr_overview}
 \title{Print a summary of a Zarr array}
 \usage{
-zarr_overview(zarr_array_path, s3_client, as_data_frame = FALSE)
+zarr_overview(zarr_array_path, s3_client = NULL, as_data_frame = FALSE)
 }
 \arguments{
 \item{zarr_array_path}{A character vector of length 1.  This provides the


### PR DESCRIPTION
Instead of missing. So NULL/missing values can be more easily passed down from dependencies.

This will become irrelevant once we have explicit zarr stores.