### PR TITLE
Make normalize_array_path() faster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 2.1.0
+Version: 2.1.1
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# Rarr 2.1
+
+## Minor improvements
+
+* `normalize_array_path()` has been slightly optimized for speed. It is not
+  likely to have a significant impact if you reading a single large array but
+  can be noticed if you reading many attributes and small arrays (as in some
+  anndata objects).
+
 # Rarr 1.99
 
 ## Breaking changes

--- a/R/s3.R
+++ b/R/s3.R
@@ -42,19 +42,19 @@ parse_s3_path <- function(path) {
 
   if (grepl(pattern = "^https?://s3\\.", x = url, ignore.case = TRUE)) {
     ## path style address
-    bucket <- gsub(
+    bucket <- sub(
       x = tmp$path,
       pattern = "^/?([a-z0-9\\.-]*)/.*",
       replacement = "\\1",
       ignore.case = TRUE
     )
-    object <- gsub(
+    object <- sub(
       x = tmp$path,
       pattern = "^/?([a-z0-9\\.-]*)/(.*)",
       replacement = "\\2",
       ignore.case = TRUE
     )
-    region <- gsub(
+    region <- sub(
       x = url,
       pattern = "^https?://s3\\.([a-z0-9-]*)\\.amazonaws\\.com/.*$",
       replacement = "\\1"
@@ -67,14 +67,14 @@ parse_s3_path <- function(path) {
     )
   ) {
     ## virtual-host style address
-    bucket <- gsub(
+    bucket <- sub(
       x = tmp$host,
       pattern = "^([a-z0-9\\.-]*)\\.s3.*",
       replacement = "\\1",
       ignore.case = TRUE
     )
-    object <- gsub("^/?(.*)", "\\1", tmp$path)
-    region <- gsub(
+    object <- sub("^/?(.*)", "\\1", tmp$path)
+    region <- sub(
       x = tmp$host,
       pattern = "^.*\\.s3\\.([a-z0-9-]*)\\.amazonaws\\.com$",
       replacement = "\\1",
@@ -98,13 +98,13 @@ parse_s3_path <- function(path) {
 #' @keywords internal
 .url_parse_other <- function(url) {
   parsed_url <- curl::curl_parse_url(url)
-  bucket <- gsub(
+  bucket <- sub(
     x = parsed_url$path,
     pattern = "^/?([[a-z0-9:\\.-]*)/.*",
     replacement = "\\1",
     ignore.case = TRUE
   )
-  object <- gsub(
+  object <- sub(
     x = parsed_url$path,
     pattern = "^/?([a-z0-9:\\.-]*)/(.*)",
     replacement = "\\2",

--- a/R/s3.R
+++ b/R/s3.R
@@ -38,35 +38,28 @@ parse_s3_path <- function(path) {
 
 #' @keywords internal
 .url_parse_aws <- function(url) {
-  tmp <- curl::curl_parse_url(url)
-
   if (grepl(pattern = "^https?://s3\\.", x = url, ignore.case = TRUE)) {
     ## path style address
-    bucket <- sub(
-      x = tmp$path,
-      pattern = "^/?([a-z0-9\\.-]*)/.*",
-      replacement = "\\1",
-      ignore.case = TRUE
-    )
-    object <- sub(
-      x = tmp$path,
-      pattern = "^/?([a-z0-9\\.-]*)/(.*)",
-      replacement = "\\2",
-      ignore.case = TRUE
-    )
-    region <- sub(
-      x = url,
-      pattern = "^https?://s3\\.([a-z0-9-]*)\\.amazonaws\\.com/.*$",
-      replacement = "\\1"
-    )
+    url_parts <- regmatches(
+      url,
+      regexec(
+        "^https?://s3\\.([a-z0-9-]*)\\.amazonaws\\.com/?([a-z0-9\\.-]*)/(.*)",
+        url,
+        ignore.case = TRUE
+      )
+    )[[1]]
+    region <- url_parts[2]
+    bucket <- url_parts[3]
+    object <- url_parts[4]
   } else if (
     grepl(
-      pattern = "^https?://[a-z0-9\\.-]*.s3\\.",
+      pattern = "^https?://[a-z0-9\\.-]*\\.s3\\.",
       x = url,
       ignore.case = TRUE
     )
   ) {
     ## virtual-host style address
+    tmp <- curl::curl_parse_url(url)
     bucket <- sub(
       x = tmp$host,
       pattern = "^([a-z0-9\\.-]*)\\.s3.*",
@@ -98,18 +91,12 @@ parse_s3_path <- function(path) {
 #' @keywords internal
 .url_parse_other <- function(url) {
   parsed_url <- curl::curl_parse_url(url)
-  bucket <- sub(
-    x = parsed_url$path,
-    pattern = "^/?([[a-z0-9:\\.-]*)/.*",
-    replacement = "\\1",
-    ignore.case = TRUE
-  )
-  object <- sub(
-    x = parsed_url$path,
-    pattern = "^/?([a-z0-9:\\.-]*)/(.*)",
-    replacement = "\\2",
-    ignore.case = TRUE
-  )
+  path_parts <- regmatches(
+    parsed_url$path,
+    regexec("^/?([a-z0-9:\\.-]*)/(.*)", parsed_url$path, ignore.case = TRUE)
+  )[[1]]
+  bucket <- path_parts[2]
+  object <- path_parts[3]
   hostname <- paste0(parsed_url$scheme, "://", parsed_url$host)
 
   if (!is.null(parsed_url$port)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -205,16 +205,9 @@ check_index <- function(index, metadata) {
 .normalize_array_path <- function(path) {
   ## we strip the protocol because it gets messed up by the slash removal later
   if (any(startsWith(path, c("http://", "https://", "s3://")))) {
-    root <- gsub(
-      x = path,
-      pattern = "^((https?://)|(s3://)).*$",
-      replacement = "\\1"
-    )
-    path <- gsub(
-      x = path,
-      pattern = "^((https?://)|(s3://))(.*$)",
-      replacement = "\\4"
-    )
+    m <- regmatches(path, regexec("^((https?://)|(s3://))(.*$)", path))[[1]]
+    root <- m[2]
+    path <- m[5]
   } else {
     ## Replace all backward slash ("\\") with forward slash ("/")
     path <- gsub(x = path, pattern = "\\", replacement = "/", fixed = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -143,7 +143,7 @@ check_index <- function(index, metadata) {
   )
 
   datatype$nbytes <- as.integer(
-    gsub(x = typestr, pattern = "^[<>|][[:alpha:]]", replacement = "")
+    sub(x = typestr, pattern = "^[<>|][[:alpha:]]", replacement = "")
   )
 
   if (datatype$base_type == "unicode") {
@@ -174,12 +174,12 @@ check_index <- function(index, metadata) {
   }
   datatype <- list()
 
-  datatype$base_type <- gsub("^([[:alpha:]]+).*", "\\1", typestr)
+  datatype$base_type <- sub("^([[:alpha:]]+).*", "\\1", typestr)
 
   # FIXME: it's awkward to have to reconvert to integer after the division
   datatype$nbytes <- as.integer(
     as.integer(
-      gsub(x = typestr, pattern = "^[^[:digit:]]+", replacement = "")
+      sub(x = typestr, pattern = "^[^[:digit:]]+", replacement = "")
     ) /
       8L
   )
@@ -219,16 +219,16 @@ check_index <- function(index, metadata) {
     ## Replace all backward slash ("\\") with forward slash ("/")
     path <- gsub(x = path, pattern = "\\", replacement = "/", fixed = TRUE)
     path <- R.utils::getAbsolutePath(path, expandTilde = TRUE)
-    root <- gsub(x = path, "(^[[:alnum:]:.]*/)?(.*)", replacement = "\\1")
-    path <- gsub(x = path, "(^[[:alnum:]:.]*/)(.*)", replacement = "\\2")
+    root <- sub(x = path, "(^[[:alnum:]:.]*/)?(.*)", replacement = "\\1")
+    path <- sub(x = path, "(^[[:alnum:]:.]*/)(.*)", replacement = "\\2")
   }
 
   ## Strip any leading "/" characters
-  path <- gsub(x = path, pattern = "^/", replacement = "", fixed = FALSE)
+  path <- sub(x = path, pattern = "^/", replacement = "", fixed = FALSE)
   ## Strip any trailing "/" characters
-  path <- gsub(x = path, pattern = "/$", replacement = "", fixed = FALSE)
+  path <- sub(x = path, pattern = "/$", replacement = "", fixed = FALSE)
   ## Collapse any sequence of more than one "/" character into a single "/"
-  path <- gsub(x = path, pattern = "//*", replacement = "/", fixed = FALSE)
+  path <- gsub(x = path, pattern = "//+", replacement = "/", fixed = FALSE)
   ## The key prefix is then obtained by appending a single "/" character to
   ## the normalized logical path.
   path <- paste0(root, path, "/")

--- a/R/utils.R
+++ b/R/utils.R
@@ -204,7 +204,7 @@ check_index <- function(index, metadata) {
 #' @keywords internal
 .normalize_array_path <- function(path) {
   ## we strip the protocol because it gets messed up by the slash removal later
-  if (grepl(x = path, pattern = "^((https?://)|(s3://)).*$")) {
+  if (any(startsWith(path, c("http://", "https://", "s3://")))) {
     root <- gsub(
       x = path,
       pattern = "^((https?://)|(s3://)).*$",


### PR DESCRIPTION
This is important in, e.g., anndataR where we read many small zarr arrays.