### PR TITLE
simplifyVector=FALSE in fromJSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .RData
 .Ruserdata
 *.Rproj
+.DS_Store
 
 config.status
 config.log

--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: all_linters(
-    packages = c("lintr"),
+    packages = "lintr",
+    from_json_simplify_linter = Rarr:::from_json_simplify_linter(),
     pipe_consistency_linter(pipe = "|>"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 2.1.4
+Version: 2.1.5
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 * Using blosc compression via variable-length types such as when using the 
   vlen-utf8 filter / codec, is no longer causing R to crash.
+* `zarr_overview()` and `read_zarr_array()` on Zarr v3 files hosted on S3. 
+  Thanks to a report and a patch by Artür Manukyan.
 
 # Rarr 1.99
 

--- a/R/dev.R
+++ b/R/dev.R
@@ -4,12 +4,14 @@
 #'
 #' @return A linter function to be used with \code{lintr::lint()}.
 #' @noRd
-from_json_simplify_linter <- lintr::make_linter_from_function_xpath(
-  function_names = "fromJSON",
-  xpath = "parent::expr[not(SYMBOL_SUB[
-    text() = 'simplifyVector' and
-    following-sibling::expr[1]/NUM_CONST[text() = 'FALSE']
-  ])]",
-  lint_message = "fromJSON() should always be called with simplifyVector = FALSE.",
-  type = "warning"
-)
+if (requireNamespace("lintr", quietly = TRUE)) {
+  from_json_simplify_linter <- lintr::make_linter_from_function_xpath(
+    function_names = "fromJSON",
+    xpath = "parent::expr[not(SYMBOL_SUB[
+      text() = 'simplifyVector' and
+      following-sibling::expr[1]/NUM_CONST[text() = 'FALSE']
+    ])]",
+    lint_message = "fromJSON() should always be called with simplifyVector = FALSE.",
+    type = "warning"
+  )
+}

--- a/R/dev.R
+++ b/R/dev.R
@@ -1,0 +1,15 @@
+# Custom linters
+
+#' Linter to enforce simplifyVector = FALSE in fromJSON calls
+#'
+#' @return A linter function to be used with \code{lintr::lint()}.
+#' @noRd
+from_json_simplify_linter <- lintr::make_linter_from_function_xpath(
+  function_names = "fromJSON",
+  xpath = "parent::expr[not(SYMBOL_SUB[
+    text() = 'simplifyVector' and
+    following-sibling::expr[1]/NUM_CONST[text() = 'FALSE']
+  ])]",
+  lint_message = "fromJSON() should always be called with simplifyVector = FALSE.",
+  type = "warning"
+)

--- a/R/read_metadata.R
+++ b/R/read_metadata.R
@@ -280,7 +280,7 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
       Key = parsed_url$object
     )
 
-    metadata <- fromJSON(rawToChar(s3_object$Body))
+    metadata <- fromJSON(rawToChar(s3_object$Body), simplifyVector = FALSE)
   } else {
     zarray_exists <- file.exists(metadata_path)
 
@@ -468,7 +468,7 @@ zarr_overview <- function(zarr_array_path, s3_client, as_data_frame = FALSE) {
       Bucket = parsed_url$bucket,
       Key = parsed_url$object
     )
-    zmeta <- fromJSON(rawToChar(s3_object$Body))
+    zmeta <- fromJSON(rawToChar(s3_object$Body), simplifyVector = FALSE)
   } else {
     zmeta <- read_json(zmeta_path)
   }

--- a/tests/testthat/_snaps/s3.md
+++ b/tests/testthat/_snaps/s3.md
@@ -39,3 +39,18 @@
       [19,]   55    0    0    0    0    0    0    0    0     0
       [20,]   58    0    0    0    0    0    0    0    0     0
 
+# JSON metadata is not unboxed
+
+    Code
+      zarr_overview(
+        "https://livingobjects.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0066/ExpA_VIP_ASLM_on_XZ_slice1088.zarr/0")
+    Output
+      Type: Array
+      Path: https://livingobjects.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0066/ExpA_VIP_ASLM_on_XZ_slice1088.zarr/0
+      Shape: 1478 x 2048
+      Chunk Shape: 1536 x 2048
+      No. of Chunks: 1 (1 x 1)
+      Data Type: uint16
+      Endianness: NA
+      Compressor: None
+

--- a/tests/testthat/test-s3.R
+++ b/tests/testthat/test-s3.R
@@ -38,3 +38,13 @@ test_that("Denied access errors return clear error messages", {
     "Denied"
   )
 })
+
+test_that("JSON metadata is not unboxed", {
+  # We don't want to save the metadata and test this locally. It has to be tested on a real S3 store because it relates
+  # to a bug in the code branch.
+  # See https://github.com/Huber-group-EMBL/Rarr/pull/170
+  zarr_overview(
+    "https://livingobjects.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0066/ExpA_VIP_ASLM_on_XZ_slice1088.zarr/0"
+  ) |>
+    expect_snapshot()
+})


### PR DESCRIPTION
Default behaviour of `fromJSON` fails reading metadata from remote stores, think this occurs for zarr v3 which we did not have an example of yet.  

Example: 

```
> s3_client <- paws.storage::s3(
+     config = list(
+         credentials = list(anonymous = TRUE),
+         region = "auto",
+         endpoint = "https://livingobjects.ebi.ac.uk/"
+     )
+ )
> x <- Rarr::read_zarr_array(
+     "https://livingobjects.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0066/ExpA_VIP_ASLM_on_XZ_slice1088.zarr/0", 
+     s3_client = s3_client
+ )
Error in vapply(metadata$codecs, function(x) gsub("-", "_", x$name, fixed = TRUE),  : 
  values must be length 1,
 but FUN(X[[1]]) result is length 0
```

after fix, stucks at sharding but at least reads the metadata.

```
Error in .configure_codecs(metadata$codecs, operation = "decode") : 
  The following codecs are not supported: sharding_indexed
```