### PR TITLE
Allow writing chunks large than full array

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: Read Zarr Files in R
-Version: 2.1.12
+Version: 2.1.13
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 * Unsupported data types are now caught explicitly and early early in the 
   reading pipeline rather than potentially failing or returning incorrect
   output later.
+* Chunks larger than the whole array in one or multiple dimensions are now
+  permitted, based on a request by Artür Manukyan.
 
 ## Bug fixes
 

--- a/R/write_data.R
+++ b/R/write_data.R
@@ -595,14 +595,15 @@ update_zarr_array <- function(zarr_array_path, x, index) {
     stop("The dimensions of the chunk must equal the dimensions of the array.")
   }
 
-  for (i in seq_along(x_dim)) {
-    # spec says:
-    # "The chunk shape elements are non-zero when the corresponding dimensions
-    # of the arrays have non-zero length."
-    if ((x_dim[i] < chunk_dim[i]) || (chunk_dim[i] == 0L && x_dim[i] != 0L)) {
-      stop("Chunk dimensions outside the extent of the array")
-    }
+  oversized_chunk <- any(chunk_dim > x_dim)
+  if (oversized_chunk) {
+    # One valid use case is nullable arrays in anndata.
+    warning(
+      "Chunk dimensions are larger than array dimensions. ",
+      "This is allowed by the Zarr specification but may lead to inefficient storage and retrieval.\n",
+      "In most cases, this is likely to be a mistake. Please check your `chunk_dim` argument.",
+      call. = FALSE
+    )
   }
-
-  return(invisible(TRUE))
+  return(invisible(!oversized_chunk))
 }


### PR DESCRIPTION
There is still a warning because it is not a good idea in most cases.

The anndata situation is a very rare edge case.