### PR TITLE
Leverage altrep for more performant indexing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ check_index <- function(index, metadata) {
   for (i in seq_len(index_len)) {
     if (is.null(index[[i]])) {
       index[[i]] <- seq_len(metadata$shape[[i]])
-    } else if (any(index[[i]] < 1L) || any(index[[i]] > metadata$shape[[i]])) {
+    } else if (min(index[[i]]) < 1L || max(index[[i]]) > metadata$shape[[i]]) {
       failed[i] <- TRUE
     } else {
       index[[i]] <- as.integer(index[[i]])

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,6 +178,7 @@ check_index <- function(index, metadata) {
   metadata,
   chunk_dim = unlist(metadata$chunk_grid$configuration$chunk_shape)
 ) {
+  index0 <- lapply(index, reindex, from = 1L, to = 0L)
   # FIXME:
   # - make this work for compat sequence that don't start at one
   # - fold the second step (index_in_chunk) here
@@ -185,11 +186,6 @@ check_index <- function(index, metadata) {
     all(vapply(index, is.compact, logical(1L))) &&
       all(vapply(index, min, integer(1L)) == 1L)
   ) {
-    shape <- metadata$shape
-    index0 <- lapply(
-      index,
-      \(i) (min(i) - 1L):(max(i) - 1L)
-    )
     per_dim <- mapply(
       \(i, cs) {
         split(
@@ -206,8 +202,7 @@ check_index <- function(index, metadata) {
       SIMPLIFY = FALSE
     )
   } else {
-    index0 <- as.integer(unlist(index)) - 1L
-
+    index0 <- unlist(index0)
     per_dim <- (index0 %/% rep(chunk_dim, times = lengths(index))) |>
       relist(index) |>
       lapply(function(x) split(seq_along(x), x))
@@ -223,20 +218,15 @@ check_index <- function(index, metadata) {
         chunk_keys[i, ],
         SIMPLIFY = FALSE
       )
-      index0_in_chunk <- mapply(
-        \(idx, pos, cs) idx[pos] %% cs,
+      index_in_chunk <- mapply(
+        \(idx, pos, cs) reindex(idx[pos] %% cs, from = 0L, to = 1L),
         index0,
         positions,
         chunk_dim,
         SIMPLIFY = FALSE
       )
-      index_in_chunk <- relist(unlist(index0_in_chunk) + 1L, index0_in_chunk)
       list(positions = positions, index_in_chunk = index_in_chunk)
     }),
     key_strings
   )
-}
-
-is.compact <- function(x) {
-  .Call("is_compact", x, PACKAGE = "Rarr")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,15 +178,43 @@ check_index <- function(index, metadata) {
   metadata,
   chunk_dim = unlist(metadata$chunk_grid$configuration$chunk_shape)
 ) {
-  index0 <- as.integer(unlist(index)) - 1L
+  # FIXME:
+  # - make this work for compat sequence that don't start at one
+  # - fold the second step (index_in_chunk) here
+  if (
+    all(vapply(index, is.compact, logical(1L))) &&
+      all(vapply(index, min, integer(1L)) == 1L)
+  ) {
+    shape <- metadata$shape
+    index0 <- lapply(
+      index,
+      \(i) (min(i) - 1L):(max(i) - 1L)
+    )
+    per_dim <- mapply(
+      \(i, cs) {
+        split(
+          i,
+          rep(
+            ((min(i) - 1L) %/% cs):((max(i) - 1L) %/% cs),
+            each = cs,
+            length.out = length(i)
+          )
+        )
+      },
+      index,
+      chunk_dim,
+      SIMPLIFY = FALSE
+    )
+  } else {
+    index0 <- as.integer(unlist(index)) - 1L
 
-  per_dim <- (index0 %/% rep(chunk_dim, times = lengths(index))) |>
-    relist(index) |>
-    lapply(function(x) split(seq_along(x), x))
-
+    per_dim <- (index0 %/% rep(chunk_dim, times = lengths(index))) |>
+      relist(index) |>
+      lapply(function(x) split(seq_along(x), x))
+    index0 <- relist(index0, index)
+  }
   chunk_keys <- do.call(expand.grid, lapply(per_dim, names))
   key_strings <- .create_chunk_names(as.matrix(chunk_keys), metadata)
-  index0 <- relist(index0, index)
   setNames(
     lapply(seq_along(key_strings), function(i) {
       positions <- mapply(
@@ -207,4 +235,8 @@ check_index <- function(index, metadata) {
     }),
     key_strings
   )
+}
+
+is.compact <- function(x) {
+  .Call("is_compact", x, PACKAGE = "Rarr")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,8 @@ check_index <- function(index, metadata) {
       index[[i]] <- seq_len(metadata$shape[[i]])
     } else if (any(index[[i]] < 1L) || any(index[[i]] > metadata$shape[[i]])) {
       failed[i] <- TRUE
+    } else {
+      index[[i]] <- as.integer(index[[i]])
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,9 @@
 #' @keywords internal
 check_index <- function(index, metadata) {
   index_len <- length(index)
+  shape <- metadata$shape
   ## check we have the correct number of dimensions
-  if (index_len != length(metadata$shape)) {
+  if (index_len != length(shape)) {
     stop(
       "The number of dimensions provided to 'index' does not match the shape of the array"
     )
@@ -13,8 +14,11 @@ check_index <- function(index, metadata) {
   failed <- rep_len(FALSE, index_len)
   for (i in seq_len(index_len)) {
     if (is.null(index[[i]])) {
-      index[[i]] <- seq_len(metadata$shape[[i]])
-    } else if (min(index[[i]]) < 1L || max(index[[i]]) > metadata$shape[[i]]) {
+      index[[i]] <- seq_len(shape[[i]])
+    } else if (
+      length(index[[i]]) > 0L &&
+        (min(index[[i]]) < 1L || max(index[[i]]) > shape[[i]])
+    ) {
       failed[i] <- TRUE
     } else {
       index[[i]] <- as.integer(index[[i]])

--- a/R/utils_altrep.R
+++ b/R/utils_altrep.R
@@ -5,7 +5,11 @@ is.compact <- function(x) {
 reindex <- function(x, from = 1L, to = 0L) {
   offset <- from - to
   if (is.compact(x)) {
-    res <- (min(x) - offset):(max(x) - offset)
+    if (is.unsorted(x)) {
+      res <- (min(x) - offset):(max(x) - offset)
+    } else {
+      res <- (x[1L] - offset):(x[length(x)] - offset)
+    }
   } else {
     res <- x - offset
   }

--- a/R/utils_altrep.R
+++ b/R/utils_altrep.R
@@ -1,0 +1,13 @@
+is.compact <- function(x) {
+  .Call("is_compact", x, PACKAGE = "Rarr")
+}
+
+reindex <- function(x, from = 1L, to = 0L) {
+  offset <- from - to
+  if (is.compact(x)) {
+    res <- (min(x) - offset):(max(x) - offset)
+  } else {
+    res <- x - offset
+  }
+  return(res)
+}

--- a/src/Rarr.c
+++ b/src/Rarr.c
@@ -2,6 +2,7 @@
 #include "decompress.h"
 #include "compress.h"
 #include "codec_vlen-utf8.h"
+#include "utils.h"
 
 static const R_CallMethodDef callMethods[] = {
   {"decompress_chunk_BLOSC", (DL_FUNC) &decompress_chunk_BLOSC, 1},
@@ -13,6 +14,8 @@ static const R_CallMethodDef callMethods[] = {
   {"compress_chunk_ZSTD", (DL_FUNC) &compress_chunk_ZSTD, 2},
 
   {"codec_vlen_utf8_decode_c", (DL_FUNC) &codec_vlen_utf8_decode_c, 2},
+
+  {"is_compact", (DL_FUNC) &is_compact, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,8 @@
+#include "utils.h"
+
+SEXP is_compact(SEXP x) {
+  if (ALTREP(x)) {
+    return ScalarLogical(TRUE);
+  }
+  return ScalarLogical(FALSE);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,4 @@
+#include "Rarr.h"
+#include <R_ext/Altrep.h>
+
+SEXP is_compact(SEXP x);


### PR DESCRIPTION
```r
cross::bench_branches({
  library(Rarr)
  bench::mark(
     SpatialData.data::MouseIntestineVisHD(), iterations = 1
  )
}, branches = "devel")
```

```
✔ Installing branch 'lazy-ind-part1'
✔ Installing branch 'devel'
✔ Running `expr` across variants
# A tibble: 2 × 14
  branch         expression                                   min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory                   time           gc              
  <chr>          <bch:expr>                              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>                   <list>         <list>          
1 lazy-ind-part1 SpatialData.data::MouseIntestineVisHD()    4.46m    4.46m   0.00374     123GB    0.164     1    44      4.46m <SpatilDt> <Rprofmem [556,807 × 3]> <bench_tm [1]> <tibble [1 × 3]>
2 devel          SpatialData.data::MouseIntestineVisHD()    4.77m    4.77m   0.00350     188GB    0.206     1    59      4.77m <SpatilDt> <Rprofmem [581,408 × 3]> <bench_tm [1]> <tibble [1 × 3]>
```