### PR TITLE
Disable SSE2 on Windows arm64

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: A Simple and Performant Native R Reader & Writer for Zarr Arrays
-Version: 2.1.29
+Version: 2.1.30
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,8 @@
   refuses to write in a non-empty location, because this could lead to 
   inconsistent or broken zarr arrays, based on a request from Hervé Pagès 
   (#136).
+* Rarr now compiles properly on Window ARM64, thanks a to report and patch from
+  Jeroen Ooms (#224).
 
 ## Internal changes
 

--- a/configure.win
+++ b/configure.win
@@ -1,26 +1,50 @@
 #!/bin/sh
 
+CC=`"${R_HOME}/bin${R_ARCH_BIN}/Rcmd.exe" config CC`
+MACHINE=`${CC} -dumpmachine 2>/dev/null`
+
+case "${MACHINE}" in
+  aarch64*|arm64*)
+    MSSE2=""
+    SSE2=""
+    SSE2_BITSHUFFLE_OBJ=""
+    SSE2_BITSHUFFLE=""
+    SSE2_SHUFFLE_OBJ=""
+    SSE2_SHUFFLE=""
+    SSE2_OBJ_PATH=""
+    ;;
+  *)
+    MSSE2="-msse2"
+    SSE2="-DSHUFFLE_SSE2_ENABLED"
+    SSE2_BITSHUFFLE_OBJ="bitshuffle-sse2.o"
+    SSE2_BITSHUFFLE='bitshuffle-sse2.o: bitshuffle-sse2.c\n\t$(CC) $(FLAGS) -c bitshuffle-sse2.c'
+    SSE2_SHUFFLE_OBJ="shuffle-sse2.o"
+    SSE2_SHUFFLE='shuffle-sse2.o: shuffle-sse2.c\n\t$(CC) $(FLAGS) -c shuffle-sse2.c'
+    SSE2_OBJ_PATH="lib/blosc-1.21.6/"
+    ;;
+esac
+
 ## use R to remove AVX2 references from BLOSC Makefiles
 "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'lines <- gsub("@M?AVX2[A-Z_]*@", "", readLines("src/compression_tools/blosc/lib/blosc-1.21.6/Makefile.in"));
-             lines <- gsub("@MSSE2@", "-msse2", lines);
-             lines <- gsub("@SSE2@", "-DSHUFFLE_SSE2_ENABLED", lines);
-             lines <- gsub("@SSE2_BITSHUFFLE_OBJ@", "bitshuffle-sse2.o", lines);
-             lines <- gsub("@SSE2_BITSHUFFLE@", "bitshuffle-sse2.o: bitshuffle-sse2.c\n\t$(CC) $(FLAGS) -c bitshuffle-sse2.c", lines);
-             lines <- gsub("@SSE2_SHUFFLE_OBJ@", "shuffle-sse2.o", lines);
-             lines <- gsub("@SSE2_SHUFFLE@", "shuffle-sse2.o: shuffle-sse2.c\n\t$(CC) $(FLAGS) -c shuffle-sse2.c", lines);
+             lines <- gsub("@MSSE2@", "'"${MSSE2}"'", lines);
+             lines <- gsub("@SSE2@", "'"${SSE2}"'", lines);
+             lines <- gsub("@SSE2_BITSHUFFLE_OBJ@", "'"${SSE2_BITSHUFFLE_OBJ}"'", lines);
+             lines <- gsub("@SSE2_BITSHUFFLE@", "'"${SSE2_BITSHUFFLE}"'", lines);
+             lines <- gsub("@SSE2_SHUFFLE_OBJ@", "'"${SSE2_SHUFFLE_OBJ}"'", lines);
+             lines <- gsub("@SSE2_SHUFFLE@", "'"${SSE2_SHUFFLE}"'", lines);
              lines <- gsub("@NO_RLIB@", "", lines);
              out_file <- file("src/compression_tools/blosc/lib/blosc-1.21.6/Makefile", open="wb");
              writeLines(lines, con = out_file, sep = "\n");
              close(out_file);'
 
 "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'lines <- gsub("@M?AVX2[A-Z_]*@", "", readLines("src/compression_tools/blosc/Makefile.in"));
-             lines <- gsub("@MSSE2@", "-msse2", lines);
-             lines <- gsub("@SSE2@", "-DSHUFFLE_SSE2_ENABLED", lines);
-             lines <- gsub("@SSE2_BITSHUFFLE_OBJ@", "bitshuffle-sse2.o", lines);
-             lines <- gsub("@SSE2_BITSHUFFLE@", "bitshuffle-sse2.o: bitshuffle-sse2.c\n\t$(CC) $(FLAGS) -c bitshuffle-sse2.c", lines);
-             lines <- gsub("@SSE2_SHUFFLE_OBJ@", "shuffle-sse2.o", lines);
-             lines <- gsub("@SSE2_SHUFFLE@", "shuffle-sse2.o: shuffle-sse2.c\n\t$(CC) $(FLAGS) -c shuffle-sse2.c", lines);
-             lines <- gsub("@SSE2_OBJ_PATH@", "lib/blosc-1.21.6/", lines);
+             lines <- gsub("@MSSE2@", "'"${MSSE2}"'", lines);
+             lines <- gsub("@SSE2@", "'"${SSE2}"'", lines);
+             lines <- gsub("@SSE2_BITSHUFFLE_OBJ@", "'"${SSE2_BITSHUFFLE_OBJ}"'", lines);
+             lines <- gsub("@SSE2_BITSHUFFLE@", "'"${SSE2_BITSHUFFLE}"'", lines);
+             lines <- gsub("@SSE2_SHUFFLE_OBJ@", "'"${SSE2_SHUFFLE_OBJ}"'", lines);
+             lines <- gsub("@SSE2_SHUFFLE@", "'"${SSE2_SHUFFLE}"'", lines);
+             lines <- gsub("@SSE2_OBJ_PATH@", "'"${SSE2_OBJ_PATH}"'", lines);
              out_file <- file("src/compression_tools/blosc/Makefile", open="wb");
              writeLines(lines, con = out_file, sep = "\n");
              close(out_file);'
@@ -29,7 +53,6 @@ sed \
 -e "s^@NO_RLIB@^^" \
 src/compression_tools/blosc/lib/snappy-1.2.2/Makefile.in > src/compression_tools/blosc/lib/snappy-1.2.2/Makefile
 
-CC=`"${R_HOME}/bin${R_ARCH_BIN}/Rcmd.exe" config CC`
 CFLAGS=`"${R_HOME}/bin${R_ARCH_BIN}/Rcmd.exe" config CFLAGS`
 CPICFLAGS=`"${R_HOME}/bin${R_ARCH_BIN}/Rcmd.exe" config CPICFLAGS`
 CXX=`"${R_HOME}/bin${R_ARCH_BIN}/Rcmd.exe" config CXX`


### PR DESCRIPTION
Hi yes me again :)

Fixes: https://github.com/r-universe/bioc/actions/runs/30404217991/job/90426829549

clang doet support `-msse2` on Windows:

```
clang-19: error: unsupported option '-msse2' for target 'aarch64-w64-mingw32'
make[2]: *** [Makefile:13: bitshuffle-sse2.o] Error 1
ERROR: compilation failed for package 'Rarr'
```

Thank you!
